### PR TITLE
🧱 Fix: Enable mobile gallery selection alongside camera capture

### DIFF
--- a/templates/upload.html
+++ b/templates/upload.html
@@ -19,7 +19,7 @@
       <input name="guest_name" id="guest_name" placeholder="e.g. Anna & Jonas" />
 
       <label for="files">📷 Photos & Videos (you can select multiple)</label>
-      <input type="file" name="files" id="files" accept="image/*,video/*" multiple capture="environment" />
+      <input type="file" name="files" id="files" accept="image/*,video/*" multiple />
 
       <button type="submit">🚀 Upload Files</button>
     </form>
@@ -28,7 +28,7 @@
       <h3>💡 Upload Tips:</h3>
       <ul>
         <li>📆 Wi-Fi works best for large video files</li>
-        <li>📱 Use "Take Photo/Video" for instant capture</li>
+        <li>📱 Choose "Camera" to take new photos or "Photo Library" to select existing ones</li>
         <li>🔄 If upload fails, try uploading fewer files at once</li>
         <li>✨ All files are organized automatically by date and name</li>
       </ul>


### PR DESCRIPTION
## 🧱 What LEGO Pieces Were Fixed

### 📱 Mobile Upload Issue Resolved
- **Problem**: Mobile users could only take new photos via camera, not select existing photos from gallery
- **Root Cause**: The `capture="environment"` attribute in the file input was forcing camera-only mode
- **Solution**: Removed the `capture` attribute to allow both camera and gallery selection

### 🔧 Changes Made
- **File Modified**: `templates/upload.html`
- **Line 22**: Removed `capture="environment"` from file input
- **Line 31**: Updated tips to reflect new capability: "Choose 'Camera' to take new photos or 'Photo Library' to select existing ones"

### ✅ Expected Behavior After Fix
- Mobile users will see options when tapping the file input:
  - 📷 **Camera** - Take new photos/videos
  - 📱 **Photo Library** - Select existing photos/videos from device
  - 📁 **Files** - Browse device files (on some devices)

### 🧪 Testing Recommendations
- Test on iOS Safari and Android Chrome
- Verify multiple file selection still works
- Confirm both camera and gallery options appear on mobile devices

---
*Like finding the right LEGO piece in your collection - now users can choose between building new memories or sharing existing ones! 🏗️*