### PR TITLE
🔒 Bump werkzeug from 3.1.4 to 3.1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==3.1.2
-Werkzeug==3.1.4
+Werkzeug==3.1.5
 gunicorn==23.0.0


### PR DESCRIPTION
## Summary
Security update for werkzeug dependency from version 3.1.4 to 3.1.5.

## Changes
- Updated werkzeug from 3.1.4 to 3.1.5 in requirements.txt

## Security Fixes
This release addresses the following security issues:
- **GHSA-87hc-h4r5-73f7**: `safe_join` on Windows no longer allows special device names, regardless of extension or surrounding spaces
- Multipart form parser now correctly handles `\r\n` sequences at chunk boundaries
- Fixed `AttributeError` when initializing `DebuggedApplication` with `pin_security=False`

## Related Issues
- Resolves #26
- Closes #25

## Test Plan
- [ ] CI pipeline passes
- [ ] Security scan completes successfully
- [ ] Application starts and serves requests correctly